### PR TITLE
createDataSource fixed to be used with dxPivotGrid

### DIFF
--- a/dx.data.linq.js
+++ b/dx.data.linq.js
@@ -59,7 +59,7 @@
             };
         }
         
-        return config;
+        return new DevExpress.data.CustomStore(config);
     }
 
     function loadOptionsToActionParams(options, isCountQuery) {


### PR DESCRIPTION
The `createDataSource` function now returns DevExpress.data.CustomStore object to fit PivotGridDataSource.